### PR TITLE
#19 add:todoTrash作成

### DIFF
--- a/components/atoms/buttons/NotStartedButton.tsx
+++ b/components/atoms/buttons/NotStartedButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@chakra-ui/react";
 
-export const NotStartedButto = () => {
+export const NotStartedButton = () => {
   return (
     <Button
       _hover={{ bg: "#F0FCFF" }}

--- a/components/organisms/Trash/TodoTrash.tsx
+++ b/components/organisms/Trash/TodoTrash.tsx
@@ -14,9 +14,17 @@ import {DoneButton} from "../../atoms/buttons/DoneButton";
 const TodoTrash:FC = () => {
 
   const TrashTable = (props: TableProps) => {
-    return <Table maxW="1080px" maxH="392px" minW="1080px" minH="392px"
-     m="168px 100px 0 100px"  {...props} />;
-  };
+  return (
+    <Table  
+      maxW="1080px"  
+      maxH="392px" 
+      minW="1080px" 
+      minH="392px" 
+      m="168px 100px 0 100px" 
+      {...props} 
+    />
+  )
+};
 
   return (
     <>

--- a/components/organisms/Trash/TodoTrash.tsx
+++ b/components/organisms/Trash/TodoTrash.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+import {
+  TableProps,
+  Table,
+  TableContainer
+} from "@chakra-ui/react";
+
+import TodoTrashTheader from "./TodoTrashTheader";
+import TodoTrashRow from "./TodoTrashRow";
+import {NotStartedButton} from "../../atoms/buttons/NotStartedButton";
+import {DoingButton} from "../../atoms/buttons/DoingButton";
+import {DoneButton} from "../../atoms/buttons/DoneButton";
+
+
+const TodoTrash:FC = () => {
+
+  const TrashTable = (props: TableProps) => {
+    return <Table maxW="1080px" maxH="392px" minW="1080px" minH="392px"
+     m="168px 100px 0 100px"  {...props} />;
+  };
+
+  return (
+    <>
+      <TableContainer>
+        <TrashTable>
+          <TodoTrashTheader />
+          <TodoTrashRow task={"邪王炎殺黒龍波"} status={<NotStartedButton/>} create={"2020-11-8 18:55"}/>
+          <TodoTrashRow task={"ReactでTodoサイトを作成する"} status={<DoingButton/>} create={"2020-11-8 18:55"}/>
+          <TodoTrashRow task={"Firestore Hostingを学習する"} status={<DoneButton/>} create={"2020-11-8 18:55"}/>
+          <TodoTrashRow task={"感謝の正拳突き"} status={<DoingButton/>} create={"2020-11-8 18:55"}/>
+          <TodoTrashRow task={"二重の極み"} status={<DoingButton/>} create={"2020-11-8 18:55"}/>
+          <TodoTrashRow task={"魔封波"} status={<DoingButton/>} create={"2020-11-8 18:55"}/>
+        </TrashTable>
+      </TableContainer>
+    </>
+  );
+};
+export default TodoTrash;

--- a/components/organisms/Trash/TodoTrash.tsx
+++ b/components/organisms/Trash/TodoTrash.tsx
@@ -11,7 +11,6 @@ import {NotStartedButton} from "../../atoms/buttons/NotStartedButton";
 import {DoingButton} from "../../atoms/buttons/DoingButton";
 import {DoneButton} from "../../atoms/buttons/DoneButton";
 
-
 const TodoTrash:FC = () => {
 
   const TrashTable = (props: TableProps) => {

--- a/components/organisms/Trash/TodoTrashRow.tsx
+++ b/components/organisms/Trash/TodoTrashRow.tsx
@@ -1,0 +1,62 @@
+import React, { FC } from "react";
+import {
+  TableColumnHeaderProps,
+  TableBodyProps,
+  Tbody,
+  Td,
+  Tr,
+} from "@chakra-ui/react";
+import PriorityButtonBox from "../../atoms/selectbox/PriorityButtonBox";
+import { RestoreButton } from "../../atoms/buttons/RestoreButton";
+import { DeleteButton } from "../../atoms/buttons/DeleteButton";
+
+type Props = {
+  task: string;
+  status: React.ReactNode;
+  create: any;
+};
+
+const TodoTrashRow: FC<Props> = (props) => {
+  const { task, status, create } = props;
+
+  const TrashTbody = (props: TableBodyProps) => {
+    return (
+      <Tbody h="56px" pb="-1" borderColor="rgba(0, 0, 0, 0.25)" {...props} />
+    );
+  };
+
+  const TrashWhiteCell = (props: TableColumnHeaderProps) => {
+    return (
+      <Td
+        maxW="174px"
+        minW="174px"
+        fontFamily="Roboto"
+        fontSize="16px"
+        color="BlackAlpha.800"
+        p="12px 10px"
+        {...props}
+      />
+    );
+  };
+  return (
+    <>
+      <TrashTbody>
+        <Tr>
+          <TrashWhiteCell maxW="384px" minW="384px" >
+            {task}
+          </TrashWhiteCell>
+          <TrashWhiteCell>{status}</TrashWhiteCell>
+          <TrashWhiteCell>
+            <PriorityButtonBox />
+          </TrashWhiteCell>
+          <TrashWhiteCell>{create}</TrashWhiteCell>
+          <TrashWhiteCell>
+            <RestoreButton />
+            <DeleteButton />
+          </TrashWhiteCell>
+        </Tr>
+      </TrashTbody>
+    </>
+  );
+};
+export default TodoTrashRow;

--- a/components/organisms/Trash/TodoTrashRow.tsx
+++ b/components/organisms/Trash/TodoTrashRow.tsx
@@ -50,9 +50,9 @@ const TodoTrashRow: FC<Props> = (props) => {
             <PriorityButtonBox />
           </TrashWhiteCell>
           <TrashWhiteCell>{create}</TrashWhiteCell>
-          <TrashWhiteCell>
-            <RestoreButton />
+          <TrashWhiteCell> 
             <DeleteButton />
+            <RestoreButton />
           </TrashWhiteCell>
         </Tr>
       </TrashTbody>

--- a/components/organisms/Trash/TodoTrashTheader.tsx
+++ b/components/organisms/Trash/TodoTrashTheader.tsx
@@ -1,0 +1,51 @@
+import {
+  TableColumnHeaderProps,
+  TableHeadProps,
+  Thead,
+  Tr,
+  Th,
+} from "@chakra-ui/react";
+import { FC } from "react";
+
+const TodoTrashTheader: FC = () => {
+  const TrashThead = (props: TableHeadProps) => {
+    return (
+      <Thead
+        h={"56px"}
+        pb="-1"
+        bgColor={"#95E3F4"}
+        borderColor="rgba(0, 0, 0, 0.25)"
+        {...props}
+      />
+    );
+  };
+
+  const TrashGreenCell = (props: TableColumnHeaderProps) => {
+    return (
+      <Th
+      w="174px"
+      textTransform="none"
+      fontFamily="Roboto"
+      fontSize="24px"
+      color="BlackAlpha.800"
+      p="12px 10px"
+      {...props}
+      />
+    );
+  };
+
+  return (
+    <>
+      <TrashThead>
+        <Tr>
+          <TrashGreenCell w="384px">Task</TrashGreenCell>
+          <TrashGreenCell>Status</TrashGreenCell>
+          <TrashGreenCell>Priority</TrashGreenCell>
+          <TrashGreenCell>Create</TrashGreenCell>
+          <TrashGreenCell>Action</TrashGreenCell>
+        </Tr>
+      </TrashThead>
+    </>
+  );
+};
+export default TodoTrashTheader;

--- a/pages/confirmationTrash.tsx
+++ b/pages/confirmationTrash.tsx
@@ -1,0 +1,15 @@
+// import TodoTrash from "../components/organisms/Trash/TodoTrash";
+
+import TodoTrash from "../components/organisms/Trash/TodoTrash";
+
+
+
+const confirmationTrash = () => {
+  
+  return (
+    <>  
+     <TodoTrash/>
+    </>
+  );
+};
+export default confirmationTrash;


### PR DESCRIPTION
#19
todoTrashのTableを作成しました！
HeaderとBodyに分けてコンポーネント分割しております！よろしくお願いします🙌
（NotStartedButtonの`n`追加しました！）
```
📦organisms
 ┣ 📂Trash
 ┃ ┣ 📜TodoTrash.tsx 　//合わせたもの
 ┃ ┣ 📜TodoTrashRow.tsx　//Tbody
 ┃ ┗ 📜TodoTrashTheader.tsx　//Theader
```
確認用
```
📦pages
 ┣ 📜CheckForm.tsx
 ┣ 📜_app.tsx
 ┣ 📜confirmationButton.tsx
 ┣ 📜confirmationSelextBox.tsx
 ┣ 📜confirmationTrash.tsx 　　　　　//確認用
 ┗ 📜index.tsx
```

作ったもの
<img width="1092" alt="Screenshot 2022-12-02 at 12 08 42" src="https://user-images.githubusercontent.com/106501752/205225025-304365a0-f3e3-4b78-9bee-9c9b67f8f38c.png">

