### PR TITLE
#23 add todo detail page

### DIFF
--- a/components/atoms/commentTable/CommentTable.tsx
+++ b/components/atoms/commentTable/CommentTable.tsx
@@ -1,0 +1,45 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import React, { FC } from "react";
+type Props = {
+  name: string;
+  day: string;
+  children: React.ReactNode;
+};
+
+const CommentTable: FC<Props> = ({ name, children, day }) => {
+  return (
+    <>
+      <Box
+        w={"472px"}
+        border={"1px"}
+        borderColor={"blackAlpha.800"}
+        h={"104px"}
+        borderRadius={"10px"}
+        mb={"16px"}
+      >
+        <Flex
+          p={"2px 25px 2px"}
+          justifyContent="space-between"
+          bg={"#28ADCA"}
+          color={"#fff"}
+          fontSize={"16px"}
+          fontWeight={"bold"}
+          borderRadius={"10px 10px 0 0"}
+        >
+          <text fontSize={"16px"} fontWeight={"bold"}>
+            {name}
+          </text>
+          <text fontSize={"16px"} fontWeight={"bold"}>
+            {day}
+          </text>
+        </Flex>
+
+        <Text p={"5px 16px 10px"} fontSize={"16px"} fontWeight={"bold"}>
+          {children}
+        </Text>
+      </Box>
+    </>
+  );
+};
+
+export default CommentTable;

--- a/components/organisms/TitleDetail.tsx
+++ b/components/organisms/TitleDetail.tsx
@@ -1,0 +1,81 @@
+import { Box, Text, Flex, Button } from "@chakra-ui/react";
+
+const TitleDetail = () => {
+  return (
+    <Box
+      w={"592px"}
+      border={"1px"}
+      borderRadius={"10px"}
+      p={"16px 16px 35px"}
+      mt={"8px"}
+    >
+      <Box mb={"16px"}>
+        <Text
+          fontSize={"24px"}
+          fontWeight={"bold"}
+          bg={"#95E3F4"}
+          borderBottom={"1px"}
+          borderColor={"blackAlpha.400"}
+          h={"28px"}
+          lineHeight={"28px"}
+        >
+          TITLE
+        </Text>
+        <Text fontSize={"20px"} fontWeight={"bold"}>
+          Github上に静的サイトをホスティングする
+        </Text>
+        <Text
+          mt={"16px"}
+          fontSize={"24px"}
+          fontWeight={"bold"}
+          bg={"#95E3F4"}
+          borderBottom={"1px"}
+          borderColor={"blackAlpha.400"}
+          h={"28px"}
+          lineHeight={"28px"}
+        >
+          DETAIL
+        </Text>
+        <Text fontSize={"20px"} fontWeight={"bold"} lineHeight={"1.2"}>
+          AWS コンソールで AWS Amplify
+          を使って静的ウェブサイトをホスティングします。AWS Amplify
+          は、静的ウェブサイトおよびウェブアプリにフルマネージドのホスティングを提供します。Amplify
+          のホスティングソリューションは、Amazon CloudFront と Amazon S3
+          を使って、AWS コンテンツ配信ネットワーク (CDN)
+          を介してサイトアセットを提供します。
+          継続的デプロイをセットアップします。Amplify は、継続的デプロイで Git
+          ベースのワークフローを提供します。それにより、コードコミットごとに、サイトに自動的に更新をデプロイすることができます。
+        </Text>
+      </Box>
+      <Flex justify={"space-between"} alignItems={"center"} h={'45px'}>
+        <Button
+          bg={"#95E3F4"}
+          w={"112px"}
+          borderRadius={"40px"}
+          fontSize={"18px"}
+        >
+          Edit
+        </Button>
+        <Box>
+          <Text fontSize={"16px"} fontWeight={"bold"}>
+            Create
+          </Text>
+          <Text fontSize={"20px"} fontWeight={"bold"}>
+            2020-11-8 18:55
+          </Text>
+        </Box>
+        <Box>
+          <Text fontSize={"16px"} fontWeight={"bold"}>
+            Update
+          </Text>
+          <Text fontSize={"20px"} fontWeight={"bold"}>
+            2020-11-8 18:55
+          </Text>
+        </Box>
+      </Flex>
+      <Box />
+    </Box>
+  );
+};
+
+export default TitleDetail;

--- a/pages/TodoDetailPage.tsx
+++ b/pages/TodoDetailPage.tsx
@@ -1,0 +1,49 @@
+import { Heading, Box, Text, Flex } from "@chakra-ui/react";
+import { BackButton } from "../components/atoms/buttons/BackButton";
+import { CommentButton } from "../components/atoms/buttons/CommentButton";
+import CommentTable from "../components/atoms/commentTable/CommentTable";
+import TitleDetail from "../components/organisms/TitleDetail";
+
+const TodoDetailPage = () => {
+  return (
+    <>
+      <Box bg="#95E3F4">
+        <Box w={"1080px"} m={"0 auto"} bg={"#95E3F4"} p={4}>
+          <Heading w={"100%"}>TODO</Heading>
+        </Box>
+      </Box>
+      <Box w={"1080px"} m={"0 auto"} px={5}>
+        <Flex justifyContent="space-between">
+          <Text fontSize={"28px"} fontWeight={"bold"} mt={"16px"}>
+            SHOW TODO
+          </Text>
+          <Flex mt={"24px"}>
+            <Box mr={"16px"}>
+              <CommentButton />
+            </Box>
+            <BackButton />
+          </Flex>
+        </Flex>
+        <Flex alignItems={"flex-end"}>
+          <TitleDetail />
+          <Box ml={"17px"} h={"464px"}>
+            <CommentTable name={"ジョン"} day={"2022/01/01"}>
+              2日後までに完了お願いします
+            </CommentTable>
+            <CommentTable name={"リンゴ"} day={"2022/01/01"}>
+              内容確認致しました。修正点メールしましたのでご確認ください。
+            </CommentTable>
+            <CommentTable name={"ポール"} day={"2022/01/01"}>
+              2日後までに完了お願いします
+            </CommentTable>
+            <CommentTable name={"ジョージ"} day={"2022/01/01"}>
+              2日後までに完了お願いします
+            </CommentTable>
+          </Box>
+        </Flex>
+      </Box>
+    </>
+  );
+};
+
+export default TodoDetailPage;


### PR DESCRIPTION
お疲れさまです。
TODOの詳細ページ（css部分）の作成を行いました。

実装ページ
[TODOの詳細ページ](http://localhost:3000/TodoDetailPage)
[![Image from Gyazo](https://i.gyazo.com/9d86d949d9b9fd22572528f891013d1f.png)](https://gyazo.com/9d86d949d9b9fd22572528f891013d1f)


```
todo詳細ページ
pages/
├── TodoDetailPage.tsx
```

ページ内の各要素はorganisms( TitleDetail.tsx)とatomos(CommentTable.tsx)内に分けて作成しました。
```
components/atoms
│   ├── commentTable
│      └── CommentTable.tsx

components/organisms
├── TitleDetail.tsx
```
ページ内のコンポーネントの分け方としてはこのような感じです。
[![Image from Gyazo](https://i.gyazo.com/e0d1d502a90a7274868a8b95a174afff.png)](https://gyazo.com/e0d1d502a90a7274868a8b95a174afff)



TodoDetailPage.tsx内（詳細ページ）からCommentTable.tsxへpropsを渡しています。
```js
<CommentTable name={"ジョン"} day={"2022/01/01"}>
　2日後までに完了お願いします
 </CommentTable>
```